### PR TITLE
Make artifactoryUrl and artifactoryRepo "optional"

### DIFF
--- a/src/main/scala/io/sysa/DebArtifactoryDeploy.scala
+++ b/src/main/scala/io/sysa/DebArtifactoryDeploy.scala
@@ -14,8 +14,8 @@ import javax.xml.bind.DatatypeConverter.printBase64Binary
 
 
 trait DebArtifactoryDeployKeys {
-  val debianArtifactoryUrl = SettingKey[String]("debian-artifactory-url", " Url of Atrifactory server")
-  val debianArtifactoryRepo = SettingKey[String]("debian-artifactory-repo", "Name of Artifactory repository with deb layout to publish artifacts to")
+  val debianArtifactoryUrl = SettingKey[Option[String]]("debian-artifactory-url", " Url of Atrifactory server")
+  val debianArtifactoryRepo = SettingKey[Option[String]]("debian-artifactory-repo", "Name of Artifactory repository with deb layout to publish artifacts to")
   val debianArtifactoryCredentials = SettingKey[Option[Credentials]]("debian-artifactory-credentials", "Credentials with permissions to publish to Artifactory server")
 
   val debianArtifactoryPath = SettingKey[String]("debian-artifactory-path", "Path in repository where the package should be stored (e.g. pool)")
@@ -52,7 +52,15 @@ object DebArtifactoryDeployPlugin extends AutoPlugin {
     (s"$repoPath/$name" +: dists ++: comps ++: archs).mkString(";")
   }
 
-  private def publishToArtifactory(artUrl: String, repo: String, targetPath: String, pkg: File, creds: Option[Credentials], streams: TaskStreams): Unit = {
+  private def publishToArtifactory(maybeArtUrl: Option[String], maybeRepo: Option[String], targetPath: String, pkg: File, creds: Option[Credentials], streams: TaskStreams): Unit = {
+    val artUrl = maybeArtUrl getOrElse {
+      sys.error("No artifactoryUrl set!")
+    }
+
+    val repo = maybeRepo getOrElse {
+      sys.error("No artifactoryRepo set!")
+    }
+
     val putTo = uri(s"$artUrl/$repo/$targetPath").normalize().toURL
 
     val connection = putTo.openConnection().asInstanceOf[HttpURLConnection]

--- a/src/main/scala/io/sysa/RpmArtifactoryDeployKeys.scala
+++ b/src/main/scala/io/sysa/RpmArtifactoryDeployKeys.scala
@@ -14,8 +14,8 @@ import javax.xml.bind.DatatypeConverter.printBase64Binary
 
 
 trait RpmArtifactoryDeployKeys {
-  val rpmArtifactoryUrl = SettingKey[String]("rpm-artifactory-url", " Url of Atrifactory server")
-  val rpmArtifactoryRepo = SettingKey[String]("rpm-artifactory-repo", "Name of Artifactory repository with YUM layout to publish artifacts to")
+  val rpmArtifactoryUrl = SettingKey[Option[String]]("rpm-artifactory-url", " Url of Atrifactory server")
+  val rpmArtifactoryRepo = SettingKey[Option[String]]("rpm-artifactory-repo", "Name of Artifactory repository with YUM layout to publish artifacts to")
   val rpmArtifactoryCredentials = SettingKey[Option[Credentials]]("rpm-artifactory-credentials", "Credentials with permissions to publish to Artifactory server")
 
   val rpmArtifactoryPath = SettingKey[String]("rpm-artifactory-path", "Path in repository where the package should be stored (e.g. pool)")
@@ -46,7 +46,15 @@ object RpmArtifactoryDeployPlugin extends AutoPlugin {
     rpmArtifactoryPublish <<= (rpmArtifactoryUrl, rpmArtifactoryRepo, rpmArtifactoryPath, rpmArtifactoryPublishName, packageBin in Rpm, rpmArtifactoryCredentials, rpmArtifactoryRecalcMetadata, streams) map publishToArtifactory
   ))
 
-  private def publishToArtifactory(artUrl: String, repo: String, path: String, name: String, pkg: File, creds: Option[Credentials], recalcMetadata: Boolean, streams: TaskStreams): Unit = {
+  private def publishToArtifactory(maybeArtUrl: Option[String], maybeRepo: Option[String], path: String, name: String, pkg: File, creds: Option[Credentials], recalcMetadata: Boolean, streams: TaskStreams): Unit = {
+    val artUrl = maybeArtUrl getOrElse {
+     sys.error("No rpmArtifactoryUrl set!")
+    }
+
+    val repo = maybeRepo getOrElse {
+      sys.error("No rpmArtifactoryRepo set!")
+    }
+
     val putTo = uri(s"$artUrl/$repo/$path/$name").normalize().toURL
 
     val connection = putTo.openConnection().asInstanceOf[HttpURLConnection]


### PR DESCRIPTION
In our "house rules" plugin, I leave `publishTo` unset if the working directory is dirty as a useful way to mistake-proof the build and prevent an untraceable build from being published. I would like to do the same for publishing debs.

I suppose only making `artifactoryUrl` optional would be sufficient, and maybe if I'm doing more, I should probably do `artifactoryPath` as well.
